### PR TITLE
prepare v0.2.2

### DIFF
--- a/manifests/0.2.2/apicast-community-operator.v0.2.2.clusterserviceversion.yaml
+++ b/manifests/0.2.2/apicast-community-operator.v0.2.2.clusterserviceversion.yaml
@@ -1,0 +1,268 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "apps.3scale.net/v1alpha1",
+          "kind": "APIcast",
+          "metadata": {
+            "name": "example-apicast"
+          },
+          "spec": {
+            "adminPortalCredentialsRef": {
+              "name": "mysecretname"
+            }
+          }
+        },
+        {
+          "apiVersion": "apps.3scale.net/v1alpha1",
+          "kind": "APIcast",
+          "metadata": {
+            "name": "example-apicast"
+          },
+          "spec": {
+            "embeddedConfigurationSecretRef": {
+              "name": "mysecretname"
+            }
+          }
+        },
+        {
+          "apiVersion": "apps.3scale.net/v1alpha1",
+          "kind": "APIcast",
+          "metadata": {
+            "name": "example-apicast"
+          },
+          "spec": {
+            "adminPortalCredentialsRef": {
+              "name": "my-admin-portal-secret-name"
+            },
+            "exposedHost": {
+              "host": "my-apicast.mydomain.com"
+            },
+            "logLevel": "debug",
+            "replicas": 2
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/3scale/apicast-operator:v0.2.0
+    createdAt: "2019-10-27T22:40:00Z"
+    description: APIcast is an API gateway built on top of NGINX. It is part of the 3scale API Management Platform
+    repository: https://github.com/3scale/apicast-operator
+    support: Red Hat, Inc.
+  name: apicast-community-operator.v0.2.2
+  namespace: placeholder
+spec:
+  replaces: apicast-community-operator.v0.2.1
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: APIcast is an API gateway
+      displayName: APIcast
+      kind: APIcast
+      name: apicasts.apps.3scale.net
+      version: v1alpha1
+  description: |
+    The APIcast Operator creates and maintains the 3scale API Gateway in several deployment configurations.
+
+    APIcast is an API gateway built on top of NGINX. It is part of the 3scale API Management Platform.
+
+    ### Supported Features
+    * **Installer** A way to install a APIcast gateway.on
+    * **Upgrade** Upgrade from previously installed APIcast gateway instance
+    * **Reconcilliation** Tunable CRD parameters after the APIcast gateway is installed
+
+    ### Upgrading your installation
+    The APIcast Operator understands how to run and upgrade between a set of APIcast versions.
+    See [the upgrade guide](https://github.com/3scale/apicast-operator/blob/v3.8/doc/operator-user-guide.md#upgrading-APIcast) for more information.
+
+    ### Documentation
+    Documentation can be found on our [website](https://github.com/3scale/apicast-operator/tree/v3.8).
+
+    ### Getting help
+    If you encounter any issues while using operator, you can create an issue on our [website](https://github.com/3scale/apicast-operator) for bugs, enhancements, or other requests.
+
+    ### Contributing
+    You can contribute by:
+
+    * Raising any issues you find using APIcast Operator
+    * Fixing issues by opening [Pull Requests](https://github.com/3scale/apicast-operator/pulls)
+    * Improving [documentation](https://github.com/3scale/apicast-operator)
+    * Talking about APIcast Operator
+
+    All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale/apicast-operator/issues).
+
+    ### License
+    APIcast Operator is licensed under the [Apache 2.0 license](https://github.com/3scale/apicast-operator/blob/master/LICENSE)
+  displayName: APIcast
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMTAwcHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDEwMCA1MCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggNTQuMSAoNzY0OTApIC0gaHR0cHM6Ly9za2V0Y2hhcHAuY29tIC0tPgogICAgPHRpdGxlPkdyb3VwIDI8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZyBpZD0iUGFnZS0xIiBzdHJva2U9Im5vbmUiIHN0cm9rZS13aWR0aD0iMSIgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgICAgICA8ZyBpZD0iR3JvdXAtMiI+CiAgICAgICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUiIGZpbGw9IiNGRkZGRkYiIHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAiIGhlaWdodD0iNTAiPjwvcmVjdD4KICAgICAgICAgICAgPGcgaWQ9Ikdyb3VwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxOS45NDY4MDksIDAuMDAwMDAwKSIgZmlsbD0iI0ZGNzMxNCIgZmlsbC1ydWxlPSJub256ZXJvIj4KICAgICAgICAgICAgICAgIDxnIGlkPSJsb2dvLW1hcmsiPgogICAgICAgICAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLDkuMDUyNjMxNjEgQzAsNCA0LjIyMzY5MTg1LDAgOS4zMTM3ODE4MywwIEMxNC41MTIxNzE1LDAgMTguNjI3NTYzOCw0LjEwNTI2MzA2IDE4LjYyNzU2MzgsOS4wNTI2MzE2MSBDMTguNjI3NTYzOCwxNC4xMDUyNjMxIDE0LjQwMzg3MiwxOC4xMDUyNjMxIDkuMzEzNzgxODMsMTguMTA1MjYzMSBDNC4yMjM2OTE4NSwxOC4xMDUyNjMxIDAsMTQuMTA1MjYzMSAwLDkuMDUyNjMxNjEgTTQ4LjYyNjYwNTQsMTEuODk0NzM2OSBDNDguNjI2NjA1NCw4Ljg0MjEwNTMyIDUxLjIyNTgwMDEsNi4zMTU3ODkzNSA1NC4zNjY0OTQyLDYuMzE1Nzg5MzUgQzU3LjUwNzE4OCw2LjMxNTc4OTM1IDYwLjEwNjM4Myw4Ljg0MjEwNTMyIDYwLjEwNjM4MywxMS44OTQ3MzY5IEM2MC4xMDYzODMsMTQuOTQ3MzY4NCA1Ny41MDcxODgsMTcuNDczNjg0NCA1NC4zNjY0OTQyLDE3LjQ3MzY4NDQgQzUxLjExNzUwMDQsMTcuNDczNjg0NCA0OC42MjY2MDU0LDE1LjA1MjYzMTYgNDguNjI2NjA1NCwxMS44OTQ3MzY5IE0zMi45MjMxMzYsMzguMTA1MjYzMSBDMzIuOTIzMTM2LDMxLjU3ODk0NzMgMzguNDQ2NDI1MiwyNi4yMTA1MjYzIDQ1LjE2MTAxMiwyNi4yMTA1MjYzIEM1MS44NzU1OTg5LDI2LjIxMDUyNjMgNTcuMzk4ODg4MiwzMS41Nzg5NDczIDU3LjM5ODg4ODIsMzguMTA1MjYzMSBDNTcuMzk4ODg4Miw0NC42MzE1NzkgNTEuODc1NTk4OSw1MCA0NS4xNjEwMTIsNTAgQzM4LjQ0NjQyNTIsNTAgMzIuOTIzMTM2LDQ0LjczNjg0MTkgMzIuOTIzMTM2LDM4LjEwNTI2MzEiIGlkPSJTaGFwZSI+PC9wYXRoPgogICAgICAgICAgICAgICAgPC9nPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: apicast-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: apicast-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: apicast-operator
+            spec:
+              containers:
+              - command:
+                - apicast-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: apicast-operator
+                - name: APICAST_IMAGE
+                  value: "quay.io/3scale/apicast:v3.8.0"
+                image: quay.io/3scale/apicast-operator:v0.2.0
+                imagePullPolicy: Always
+                name: apicast-operator
+                resources: {}
+              serviceAccountName: apicast-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - apicast-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps.3scale.net
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: apicast-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - 3scale
+  - API
+  - api
+  - APIcast
+  - apicast
+  - gateway
+  - api-gateway
+  - openresty
+  links:
+  - name: GitHub
+    url: https://github.com/3scale/apicast-operator
+  - name: Documentation
+    url: https://github.com/3scale/apicast-operator/tree/v3.8
+  maintainers:
+  - email: eastizle+apicastoperator@redhat.com
+    name: Apicast
+  - email: msoriano+apicastoperator@redhat.com
+    name: Apicast
+  maturity: stable
+  minKubeVersion: 1.11.0
+  provider:
+    name: Red Hat
+  version: 0.2.2

--- a/manifests/0.2.2/apps_v1alpha1_apicast_crd.yaml
+++ b/manifests/0.2.2/apps_v1alpha1_apicast_crd.yaml
@@ -1,0 +1,172 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apicasts.apps.3scale.net
+spec:
+  group: apps.3scale.net
+  names:
+    kind: APIcast
+    listKind: APIcastList
+    plural: apicasts
+    singular: apicast
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: APIcast is the Schema for the apicasts API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: APIcastSpec defines the desired state of APIcast
+          properties:
+            adminPortalCredentialsRef:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
+            cacheConfigurationSeconds:
+              format: int64
+              type: integer
+            configurationLoadMode:
+              enum:
+              - boot
+              - lazy
+              type: string
+            deploymentEnvironment:
+              type: string
+            dnsResolverAddress:
+              type: string
+            embeddedConfigurationSecretRef:
+              description: LocalObjectReference contains enough information to let
+                you locate the referenced object inside the same namespace.
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
+            enabledServices:
+              items:
+                type: string
+              type: array
+            exposedHost:
+              properties:
+                host:
+                  type: string
+                tls:
+                  items:
+                    description: IngressTLS describes the transport layer security
+                      associated with an Ingress.
+                    properties:
+                      hosts:
+                        description: Hosts are a list of hosts included in the TLS
+                          certificate. The values in this list must match the name/s
+                          used in the tlsSecret. Defaults to the wildcard host setting
+                          for the loadbalancer controller fulfilling this Ingress,
+                          if left unspecified.
+                        items:
+                          type: string
+                        type: array
+                      secretName:
+                        description: SecretName is the name of the secret used to
+                          terminate SSL traffic on 443. Field is left optional to
+                          allow SSL routing based on SNI hostname alone. If the SNI
+                          host in a listener conflicts with the "Host" header field
+                          used by an IngressRule, the SNI host is used for termination
+                          and value of the Host header is used for routing.
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - host
+              type: object
+            image:
+              type: string
+            logLevel:
+              enum:
+              - debug
+              - info
+              - notice
+              - warn
+              - error
+              - crit
+              - alert
+              - emerg
+              type: string
+            managementAPIScope:
+              enum:
+              - disabled
+              - status
+              - policies
+              - debug
+              type: string
+            openSSLPeerVerificationEnabled:
+              type: boolean
+            pathRoutingEnabled:
+              type: boolean
+            replicas:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              format: int64
+              type: integer
+            responseCodesIncluded:
+              type: boolean
+            serviceAccount:
+              type: string
+          type: object
+          anyOf:
+           - properties:
+               adminPortalCredentialsRef:
+                 type: object
+             required: ["adminPortalCredentialsRef"]
+           - properties:
+               embeddedConfigurationSecretRef:
+                 type: object
+             required: ["embeddedConfigurationSecretRef"]
+        status:
+          description: APIcastStatus defines the observed state of APIcast
+          properties:
+            conditions:
+              description: Represents the latest available observations of a replica
+                set's current state.
+              items:
+                properties:
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of replica set condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            image:
+              description: The image being used in the APIcast deployment
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/apicast-community-operator.package.yaml
+++ b/manifests/apicast-community-operator.package.yaml
@@ -1,7 +1,7 @@
 packageName: apicast-community-operator
 channels:
   - name: alpha
-    currentCSV: apicast-community-operator.v0.2.1
+    currentCSV: apicast-community-operator.v0.2.2
   - name: stable
-    currentCSV: apicast-community-operator.v0.2.1
+    currentCSV: apicast-community-operator.v0.2.2
 defaultChannel: stable


### PR DESCRIPTION
* Fixes ingress support OCP

Diff 0.2.1 and 0.2.2

```
$ diff manifests/0.2.1/apicast-community-operator.v0.2.1.clusterserviceversion.yaml  manifests/0.2.2/apicast-community-operator.v0.2.2.clusterserviceversion.yaml
4a5,48
>     alm-examples: |-
>       [
>         {
>           "apiVersion": "apps.3scale.net/v1alpha1",
>           "kind": "APIcast",
>           "metadata": {
>             "name": "example-apicast"
>           },
>           "spec": {
>             "adminPortalCredentialsRef": {
>               "name": "mysecretname"
>             }
>           }
>         },
>         {
>           "apiVersion": "apps.3scale.net/v1alpha1",
>           "kind": "APIcast",
>           "metadata": {
>             "name": "example-apicast"
>           },
>           "spec": {
>             "embeddedConfigurationSecretRef": {
>               "name": "mysecretname"
>             }
>           }
>         },
>         {
>           "apiVersion": "apps.3scale.net/v1alpha1",
>           "kind": "APIcast",
>           "metadata": {
>             "name": "example-apicast"
>           },
>           "spec": {
>             "adminPortalCredentialsRef": {
>               "name": "my-admin-portal-secret-name"
>             },
>             "exposedHost": {
>               "host": "my-apicast.mydomain.com"
>             },
>             "logLevel": "debug",
>             "replicas": 2
>           }
>         }
>       ]
6c50
<     categories: "Integration & Delivery"
---
>     categories: Integration & Delivery
13,16c57
<     alm-examples: >-
<        [{"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIcast","metadata":{"name":"example-apicast"},"spec":{"adminPortalCredentialsRef":{"name":"mysecretname"}}},
<        {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIcast","metadata":{"name":"example-apicast"},"spec":{"embeddedConfigurationSecretRef":{"name":"mysecretname"}}}]
<   name: apicast-community-operator.v0.2.1
---
>   name: apicast-community-operator.v0.2.2
19c60
<   replaces: apicast-community-operator.v0.1.1
---
>   replaces: apicast-community-operator.v0.2.1
86c127
<                       fieldPath: metadata.namespace
---
>                       fieldPath: metadata.annotations['olm.targetNamespaces']
106a148
>           - services/finalizers
113c155,161
<           - '*'
---
>           - create
>           - delete
>           - get
>           - list
>           - patch
>           - update
>           - watch
122,128c170,176
<           - '*'
<         - apiGroups:
<           - extensions
<           resources:
<           - ingresses
<           verbs:
<           - '*'
---
>           - create
>           - delete
>           - get
>           - list
>           - patch
>           - update
>           - watch
144a193,198
>           - ""
>           resources:
>           - pods
>           verbs:
>           - get
>         - apiGroups:
149c203,233
<           - '*'
---
>           - create
>           - delete
>           - get
>           - list
>           - patch
>           - update
>           - watch
>         - apiGroups:
>           - extensions
>           resources:
>           - ingresses
>           verbs:
>           - create
>           - delete
>           - get
>           - list
>           - patch
>           - update
>           - watch
>         - apiGroups:
>           - route.openshift.io
>           resources:
>           - routes/custom-host
>           verbs:
>           - create
>           - delete
>           - get
>           - list
>           - patch
>           - update
>           - watch
180c264
<   maturity: alpha
---
>   maturity: stable
184c268
<   version: 0.2.1
---
>   version: 0.2.2
```